### PR TITLE
Fix: let fetch errors bubble up

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,10 @@ import status from './methods/status.js';
 import details from './methods/details.js';
 import subscribe from './methods/subscribe.js';
 
-import { config } from './types.js';
+import { config, TinyResult, TinyOptions } from './types.js';
+interface FetchOptions extends TinyOptions {
+  method: keyof typeof tiny;
+}
 
 const API_URL_US = 'https://api-production.august.com';
 const API_URL_NON_US = 'https://api.aaecosystem.com';
@@ -28,8 +31,9 @@ class August {
     this.config = setup(config);
   }
 
-  async fetch({ method, ...params }: { method: string, [key: string]: any }) {
-    const API_URL = this.config.countryCode === 'US' ? API_URL_US : API_URL_NON_US;
+  async fetch({ method, ...params }: FetchOptions): Promise<TinyResult> {
+    const API_URL =
+      this.config.countryCode === 'US' ? API_URL_US : API_URL_NON_US;
 
     // Ensure proper url
     if (!params.url.startsWith(API_URL)) {
@@ -38,24 +42,11 @@ class August {
       }
       params.url = API_URL + params.url;
     }
-    try {
-      // Keep this `await` - it allows us to catch errors from tiny
-      // console.log('REQUEST', method, params)
-      const res = await (tiny as any)[method](params);
-      // console.log('RESPONSE', res)
-      return res;
-    } catch (err: any) {
-      // Convert giagantic error to a more manageable one
-      let errorMessage;
-      if (err.statusCode) {
-        errorMessage = `FetchError: Status ${err.statusCode} (${err.body.code}): ${err.body.message}`;
-      } else {
-        errorMessage = err;
-      }
 
-      console.error(errorMessage);
-      return {};
-    }
+    // console.log('REQUEST', method, params)
+    const res = await tiny[method](params);
+    // console.log('RESPONSE', res)
+    return res;
   }
 
   /* --------------------------------- Session -------------------------------- */

--- a/src/types.ts
+++ b/src/types.ts
@@ -155,4 +155,20 @@ export type AugustUser = {
     FirstName: string,
     LastName: string,
     identifiers: Array<any>
+
+// via @types/tiny-json-http
+export interface TinyResult {
+  body: any;
+  headers: any;
+}
+
+export interface TinyOptions {
+  url: string;
+  data?: any;
+  headers?: any;
+  /**
+   * Set to true the response body is returned as a buffer
+   */
+  buffer?: boolean | undefined;
+  timeout?: number | undefined;
 }


### PR DESCRIPTION


## :recycle: Current situation && :bulb: Proposed solution

Fixes #3

Rather than letting the errors from a call to the fetch method get swallowed, we let them throw and let the user decide how to handle them. The code that was there previously seems handy for development, but is atypical for production.

This also leads to more reliable typing by avoiding returning an empty object in the error case.

I don't love copying types out of the `@types/tiny-json-http` module, but it doesn't expose the types we need and due to type overloading, I wasn't able to extract them with tricks like `Parameters` or `ReturnType`.

A cleaner fix would be to modify that module to export what we need, but I've only got so many hours in the day ;)

## :gear: Release Notes

[Consider making this a major release since this is _technically_ a breaking change]

- [Breaking] Previously, failures from the August/Yale API were logged with `console.error`. This change removes that behavior and throws an exception to let the library user decide how to handle it.
