### PR TITLE
Add: concurrent session requests eliminated

### DIFF
--- a/src/util/session.ts
+++ b/src/util/session.ts
@@ -1,3 +1,5 @@
+let request: Promise<any> | null = null;
+
 /**
  * * Start or continue a session
  * If token not saved, fetch a new token
@@ -22,7 +24,11 @@ export default async function session(this: any): Promise<object> {
 
     const data = { installId, identifier, password };
 
-    const response = await this.fetch({ method: 'post', url: 'session', headers, data });
+    if (request === null) {
+      request = this.fetch({ method: 'post', url: 'session', headers, data });
+    }
+    const response = await request;
+    request = null;
 
     this.token = response.headers['x-august-access-token'];
     headers['x-august-access-token'] = this.token;


### PR DESCRIPTION
## :recycle: Current situation && :bulb: Proposed solution

Fixes #4

This eliminates concurrent requests to the `session` API endpoint by caching the first request and returning it's result to subsequent calls as long as the request is still in flight. This should be a small help in avoiding rate-limiting.

## :gear: Release Notes

Added a little more defense against rate limiting by eliminating some concurrent requests to the August/Yale API

## :heavy_plus_sign: Additional Information
*If applicable, provide additional context in this section.*

### Testing

¯\_(ツ)_/¯ I just translated what I had manually modified this package running in homebridge. It seems to have worked there.
