### PR TITLE
fix: properly manage PubNub instance lifecycle in subscribe()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import details from './methods/details.js'
 import lockUnlock from './methods/lock-unlock.js'
 import locks from './methods/locks.js'
 import status from './methods/status.js'
-import subscribe from './methods/subscribe.js'
+import subscribe, { tearDownPubNub } from './methods/subscribe.js'
 import validate from './methods/validate.js'
 import unlatch from './methods/unlatch.js'
 import houses, { houseDetails, houseActivities, houseTemperature } from './methods/houses.js'
@@ -123,6 +123,22 @@ class August {
   end() {
     // End the session (called automatically in every method below except where noted)
     this.token = null
+  }
+
+  /**
+   * Fully tear down this August instance: clears the session token and
+   * destroys any PubNub subscription. Call this when you're done with
+   * the instance and want to release all resources (WebSocket connection,
+   * listeners, timers).
+   *
+   * Unlike end(), which is called internally after most API calls and
+   * only clears the HTTP auth token, destroy() also tears down the
+   * PubNub connection used by subscribe(). After destroy(), any active
+   * subscriptions on this instance are stopped.
+   */
+  destroy() {
+    this.token = null
+    tearDownPubNub(this)
   }
 
   /* ---------------------------------- Auth ---------------------------------- */

--- a/src/methods/subscribe.test.ts
+++ b/src/methods/subscribe.test.ts
@@ -1,9 +1,280 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import subscribe from './subscribe'
+// Mock the PubNub module before importing subscribe
+const mockPubNubInstances: any[] = []
 
-describe('subscribe method', () => {
+vi.mock('pubnub', () => {
+  return {
+    default: vi.fn().mockImplementation(() => {
+      const listeners: any[] = []
+      const subscribedChannels = new Set<string>()
+      const instance = {
+        addListener: vi.fn((listener: any) => {
+          listeners.push(listener)
+        }),
+        subscribe: vi.fn(({ channels }: { channels: string[] }) => {
+          channels.forEach(c => subscribedChannels.add(c))
+        }),
+        unsubscribe: vi.fn(({ channels }: { channels: string[] }) => {
+          channels.forEach(c => subscribedChannels.delete(c))
+        }),
+        unsubscribeAll: vi.fn(() => {
+          subscribedChannels.clear()
+        }),
+        removeAllListeners: vi.fn(() => {
+          listeners.length = 0
+        }),
+        destroy: vi.fn(),
+        _listeners: listeners,
+        _subscribedChannels: subscribedChannels,
+        _simulateMessage: (event: any) => {
+          listeners.forEach(l => l.message?.(event))
+        },
+      }
+      mockPubNubInstances.push(instance)
+      return instance
+    }),
+  }
+})
+
+const subscribeModule = await import('./subscribe')
+const subscribe = subscribeModule.default
+const { tearDownPubNub } = subscribeModule
+
+function makeFakeAugust(options: { lockIds?: string[], pubsubChannels?: Record<string, string> } = {}) {
+  const lockIds = options.lockIds ?? ['lock-1']
+  const channels = options.pubsubChannels ?? { 'lock-1': 'channel-1' }
+  const august: any = {
+    config: {
+      pnSubKey: 'sub-key',
+      augustId: 'user@example.com',
+    },
+    end: vi.fn(),
+    addSimpleProps: vi.fn((msg: any) => {
+      msg._propsAdded = true
+    }),
+    _locks: vi.fn(async () => {
+      const result: Record<string, any> = {}
+      lockIds.forEach((id) => {
+        result[id] = {}
+      })
+      return result
+    }),
+    _details: vi.fn(async (lockId: string) => ({
+      pubsubChannel: channels[lockId],
+    })),
+    _subscribe: vi.fn(async function (this: any, id: string, cb: any) {
+      return subscribe.call(this, id, cb, true)
+    }),
+  }
+  return august
+}
+
+describe('subscribe method - basic', () => {
+  beforeEach(() => {
+    mockPubNubInstances.length = 0
+  })
+
   it('should be a function', () => {
     expect(typeof subscribe).toBe('function')
+  })
+
+  it('returns an unsubscribe function', async () => {
+    const august = makeFakeAugust()
+    const unsub = await subscribe.call(august, 'lock-1', vi.fn(), false)
+    expect(typeof unsub).toBe('function')
+  })
+})
+
+describe('subscribe method - PubNub instance sharing', () => {
+  beforeEach(() => {
+    mockPubNubInstances.length = 0
+  })
+
+  it('creates only one PubNub instance for multiple subscriptions on the same August instance', async () => {
+    const august = makeFakeAugust({
+      lockIds: ['lock-1', 'lock-2', 'lock-3'],
+      pubsubChannels: {
+        'lock-1': 'channel-1',
+        'lock-2': 'channel-2',
+        'lock-3': 'channel-3',
+      },
+    })
+
+    await subscribe.call(august, 'lock-1', vi.fn(), false)
+    await subscribe.call(august, 'lock-2', vi.fn(), false)
+    await subscribe.call(august, 'lock-3', vi.fn(), false)
+
+    // Core leak fix: previously each call created a new PubNub
+    expect(mockPubNubInstances.length).toBe(1)
+  })
+
+  it('subscribes to the correct channel for each lock', async () => {
+    const august = makeFakeAugust({
+      lockIds: ['lock-1', 'lock-2'],
+      pubsubChannels: { 'lock-1': 'channel-1', 'lock-2': 'channel-2' },
+    })
+
+    await subscribe.call(august, 'lock-1', vi.fn(), false)
+    await subscribe.call(august, 'lock-2', vi.fn(), false)
+
+    const pn = mockPubNubInstances[0]
+    expect(pn._subscribedChannels.has('channel-1')).toBe(true)
+    expect(pn._subscribedChannels.has('channel-2')).toBe(true)
+  })
+
+  it('creates separate PubNub instances for separate August instances', async () => {
+    const august1 = makeFakeAugust()
+    const august2 = makeFakeAugust()
+    await subscribe.call(august1, 'lock-1', vi.fn(), false)
+    await subscribe.call(august2, 'lock-1', vi.fn(), false)
+    expect(mockPubNubInstances.length).toBe(2)
+  })
+})
+
+describe('subscribe method - unsubscribe cleanup', () => {
+  beforeEach(() => {
+    mockPubNubInstances.length = 0
+  })
+
+  it('unsubscribe removes the callback and unsubscribes from channel', async () => {
+    const august = makeFakeAugust()
+    const cb = vi.fn()
+    const unsub = await subscribe.call(august, 'lock-1', cb, false)
+
+    const pn = mockPubNubInstances[0]
+    expect(pn._subscribedChannels.has('channel-1')).toBe(true)
+
+    unsub()
+    expect(pn._subscribedChannels.has('channel-1')).toBe(false)
+  })
+
+  it('destroys the PubNub instance when the last subscription is removed', async () => {
+    const august = makeFakeAugust()
+    const unsub = await subscribe.call(august, 'lock-1', vi.fn(), false)
+
+    const pn = mockPubNubInstances[0]
+    expect(pn.destroy).not.toHaveBeenCalled()
+
+    unsub()
+    expect(pn.destroy).toHaveBeenCalledOnce()
+    expect(pn.removeAllListeners).toHaveBeenCalledOnce()
+  })
+
+  it('does not destroy the PubNub instance while other subscriptions remain', async () => {
+    const august = makeFakeAugust({
+      lockIds: ['lock-1', 'lock-2'],
+      pubsubChannels: { 'lock-1': 'channel-1', 'lock-2': 'channel-2' },
+    })
+    const unsub1 = await subscribe.call(august, 'lock-1', vi.fn(), false)
+    await subscribe.call(august, 'lock-2', vi.fn(), false)
+
+    const pn = mockPubNubInstances[0]
+    unsub1()
+    expect(pn.destroy).not.toHaveBeenCalled()
+    expect(pn._subscribedChannels.has('channel-1')).toBe(false)
+    expect(pn._subscribedChannels.has('channel-2')).toBe(true)
+  })
+
+  it('unsubscribe is idempotent - calling twice is safe', async () => {
+    const august = makeFakeAugust()
+    const unsub = await subscribe.call(august, 'lock-1', vi.fn(), false)
+
+    const pn = mockPubNubInstances[0]
+    unsub()
+    unsub()
+    unsub()
+
+    expect(pn.destroy).toHaveBeenCalledOnce()
+  })
+})
+
+describe('subscribe method - multiple callbacks per channel', () => {
+  beforeEach(() => {
+    mockPubNubInstances.length = 0
+  })
+
+  it('allows multiple callbacks on the same channel without subscribing twice', async () => {
+    const august = makeFakeAugust()
+    await subscribe.call(august, 'lock-1', vi.fn(), false)
+    await subscribe.call(august, 'lock-1', vi.fn(), false)
+
+    const pn = mockPubNubInstances[0]
+    expect(pn.subscribe).toHaveBeenCalledOnce()
+  })
+
+  it('dispatches messages to all callbacks for a channel', async () => {
+    const august = makeFakeAugust()
+    const cb1 = vi.fn()
+    const cb2 = vi.fn()
+    await subscribe.call(august, 'lock-1', cb1, false)
+    await subscribe.call(august, 'lock-1', cb2, false)
+
+    const pn = mockPubNubInstances[0]
+    pn._simulateMessage({
+      channel: 'channel-1',
+      message: { status: 'locked' },
+      timetoken: '123',
+    })
+
+    expect(cb1).toHaveBeenCalledOnce()
+    expect(cb2).toHaveBeenCalledOnce()
+  })
+
+  it('unsubscribing one callback does not affect the other', async () => {
+    const august = makeFakeAugust()
+    const cb1 = vi.fn()
+    const cb2 = vi.fn()
+    const unsub1 = await subscribe.call(august, 'lock-1', cb1, false)
+    await subscribe.call(august, 'lock-1', cb2, false)
+
+    unsub1()
+
+    const pn = mockPubNubInstances[0]
+    expect(pn._subscribedChannels.has('channel-1')).toBe(true)
+    pn._simulateMessage({
+      channel: 'channel-1',
+      message: { status: 'locked' },
+      timetoken: '123',
+    })
+    expect(cb1).not.toHaveBeenCalled()
+    expect(cb2).toHaveBeenCalledOnce()
+  })
+})
+
+describe('subscribe method - tearDownPubNub', () => {
+  beforeEach(() => {
+    mockPubNubInstances.length = 0
+  })
+
+  it('tears down all subscriptions on the instance', async () => {
+    const august = makeFakeAugust({
+      lockIds: ['lock-1', 'lock-2'],
+      pubsubChannels: { 'lock-1': 'channel-1', 'lock-2': 'channel-2' },
+    })
+    await subscribe.call(august, 'lock-1', vi.fn(), false)
+    await subscribe.call(august, 'lock-2', vi.fn(), false)
+
+    tearDownPubNub(august)
+
+    const pn = mockPubNubInstances[0]
+    expect(pn.removeAllListeners).toHaveBeenCalled()
+    expect(pn.destroy).toHaveBeenCalled()
+  })
+
+  it('is safe to call when no PubNub instance exists', () => {
+    const august = makeFakeAugust()
+    expect(() => tearDownPubNub(august)).not.toThrow()
+  })
+
+  it('is idempotent', async () => {
+    const august = makeFakeAugust()
+    await subscribe.call(august, 'lock-1', vi.fn(), false)
+
+    const pn = mockPubNubInstances[0]
+    tearDownPubNub(august)
+    tearDownPubNub(august)
+
+    expect(pn.destroy).toHaveBeenCalledOnce()
   })
 })

--- a/src/methods/subscribe.ts
+++ b/src/methods/subscribe.ts
@@ -1,25 +1,69 @@
 import PubNub from 'pubnub'
 
-const lockChannels = new Map()
+/**
+ * Channel cache: lockId -> pubsubChannel.
+ * Module-level cache of lock details, not instance state.
+ */
+const lockChannels = new Map<string, string>()
 
 /**
- * Subscribe to lock events
+ * Per-August-instance PubNub state. Keyed by the August instance itself
+ * using a WeakMap so garbage collection of the instance also clears state.
+ */
+interface PubNubState {
+  pubnub: PubNub
+  // channel -> set of callbacks subscribed to that channel
+  subscriptions: Map<string, Set<(message: any, timetoken: any) => void>>
+}
+const instanceState = new WeakMap<object, PubNubState>()
+
+/**
+ * Tear down the PubNub instance associated with this August instance.
+ * Called when no subscriptions remain, or externally via cleanup paths.
+ */
+export function tearDownPubNub(august: object): void {
+  const state = instanceState.get(august)
+  if (!state) {
+    return
+  }
+  try {
+    state.pubnub.removeAllListeners()
+    state.pubnub.unsubscribeAll()
+    state.pubnub.destroy()
+  } catch {
+    // Best-effort cleanup; swallow any errors during teardown
+  }
+  instanceState.delete(august)
+}
+
+/**
+ * Subscribe to lock events.
+ *
+ * Returns an idempotent unsubscribe function. Multiple calls to subscribe()
+ * for different locks on the same August instance share a single PubNub
+ * WebSocket connection. The connection is only torn down when the last
+ * subscription is removed.
  *
  * @param {string} [lockId]
  * @param {Function} callback
  */
-export default async function subscribe(this: any, lockId: any, callback: any, internal: any): Promise<() => void> {
+export default async function subscribe(
+  this: any,
+  lockId: any,
+  callback: any,
+  internal: any,
+): Promise<() => void> {
   if (!lockId) {
     const locks = Object.keys(await this._locks())
     if (locks.length > 1) {
       // Multiple locks, subscribe to all (use iteration)
       const unsubscribes = await Promise.all(locks.map(id => this._subscribe(id, callback)))
-      return () => unsubscribes.forEach(unsubscribe => unsubscribe()) as unknown as () => void
+      return () => unsubscribes.forEach(unsubscribe => unsubscribe())
     }
-    // Otherwise continue with the only lock
     lockId = locks[0]
   }
 
+  // Resolve and cache the pubsub channel for this lock
   if (!lockChannels.has(lockId)) {
     const details = await this._details(lockId)
     if (!details?.pubsubChannel) {
@@ -29,7 +73,6 @@ export default async function subscribe(this: any, lockId: any, callback: any, i
       }
       return () => {}
     }
-    // Cache the pubsub channel for this lock
     lockChannels.set(lockId, details.pubsubChannel)
   }
 
@@ -37,32 +80,84 @@ export default async function subscribe(this: any, lockId: any, callback: any, i
     this.end()
   }
 
-  const channel = lockChannels.get(lockId)
+  const channel = lockChannels.get(lockId)!
 
-  const pnconfig = {
-    subscribeKey: this.config.pnSubKey,
-    uuid: `pn-${this.config.augustId.toUpperCase()}`,
+  // Get or create the shared PubNub instance for this August instance
+  let state = instanceState.get(this)
+  if (!state) {
+    const pubnub = new PubNub({
+      subscribeKey: this.config.pnSubKey,
+      uuid: `pn-${this.config.augustId.toUpperCase()}`,
+    })
+    state = {
+      pubnub,
+      subscriptions: new Map(),
+    }
+    instanceState.set(this, state)
+
+    // Single shared listener that dispatches to per-channel callback sets.
+    // Previously each subscribe() call added a new listener to a fresh
+    // PubNub instance, which leaked both the listener and the instance.
+    pubnub.addListener({
+      message: (event: any) => {
+        const callbacks = state!.subscriptions.get(event.channel)
+        if (!callbacks) {
+          return
+        }
+        const { message, timetoken } = event
+        this.addSimpleProps(message)
+        if (!message.lockId) {
+          // Fall back to the first lockId known for this channel
+          for (const [cachedLockId, cachedChannel] of lockChannels.entries()) {
+            if (cachedChannel === event.channel) {
+              message.lockId = cachedLockId
+              break
+            }
+          }
+        }
+        for (const cb of callbacks) {
+          cb(message, timetoken)
+        }
+      },
+    })
   }
 
-  const pubnub = new PubNub(pnconfig)
+  // Register this callback for this channel
+  let callbacks = state.subscriptions.get(channel)
+  if (!callbacks) {
+    callbacks = new Set()
+    state.subscriptions.set(channel, callbacks)
+    state.pubnub.subscribe({ channels: [channel] })
+  }
+  callbacks.add(callback)
 
-  pubnub.addListener({
-    message: (event: any) => {
-      const { message, timetoken } = event
-      this.addSimpleProps(message)
-      if (!message.lockId) {
-        message.lockId = lockId
+  // Return an idempotent unsubscribe function
+  let unsubscribed = false
+  return () => {
+    if (unsubscribed) {
+      return
+    }
+    unsubscribed = true
+    const currentState = instanceState.get(this)
+    if (!currentState) {
+      return
+    }
+    const currentCallbacks = currentState.subscriptions.get(channel)
+    if (!currentCallbacks) {
+      return
+    }
+    currentCallbacks.delete(callback)
+    if (currentCallbacks.size === 0) {
+      currentState.subscriptions.delete(channel)
+      try {
+        currentState.pubnub.unsubscribe({ channels: [channel] })
+      } catch {
+        // Best-effort; channel may already be unsubscribed
       }
-      callback?.(message, timetoken)
-    },
-  })
-
-  pubnub.subscribe({
-    channels: [channel],
-  })
-
-  return () =>
-    pubnub.unsubscribe({
-      channels: [channel],
-    })
+    }
+    // Tear down the PubNub instance entirely when no channels remain
+    if (currentState.subscriptions.size === 0) {
+      tearDownPubNub(this)
+    }
+  }
 }


### PR DESCRIPTION
# fix: properly manage PubNub instance lifecycle in subscribe()

## :recycle: Current situation

Every call to `subscribe()` creates a brand new `PubNub` instance with its own WebSocket connection, message listener, heartbeat timers, and captured closures. The returned unsubscribe function only calls `pubnub.unsubscribe({ channels })` - it does NOT call `removeAllListeners()` or `destroy()`. The PubNub instance itself stays alive even after "unsubscribing."

For applications that subscribe repeatedly (e.g. homebridge-august on session refresh), this causes unbounded memory growth.

There are also a couple of smaller design issues that compound the problem:

1. One PubNub instance per lock, even though PubNub natively supports subscribing to multiple channels from a single client. N locks = N WebSocket connections to PubNub.
2. No support for multiple callbacks on the same channel - each new subscription always creates a new PubNub instance and registers a new listener, even for the same lock.
3. The unsubscribe function is not idempotent - calling it twice has undefined behavior.

## :bulb: Proposed solution

Redesign `subscribe.ts` to manage PubNub lifecycle per August instance rather than per subscription:

**One PubNub instance per August instance.** State is tracked in a module-level `WeakMap` keyed on the August instance itself, so when the instance is garbage collected the PubNub state is too. The first `subscribe()` call creates the PubNub instance and registers a single shared message listener. Subsequent calls on the same August instance reuse the existing PubNub, adding channel subscriptions as needed.

**Shared listener dispatches to per-channel callback sets.** The single listener routes each incoming message to the set of callbacks registered for that channel. Multiple callbacks per channel are supported without creating multiple PubNub instances.

**Proper teardown in the unsubscribe function.** The returned function:
1. Removes just the specific callback that was passed to `subscribe()`
2. If no callbacks remain on that channel, calls `pubnub.unsubscribe({ channels })`
3. If no channels remain, calls `pubnub.removeAllListeners()` then `pubnub.destroy()` to fully terminate the WebSocket and clear all timers
4. Is idempotent - safe to call multiple times

**New `destroy()` method on the August class** for callers who want to explicitly release all resources (both the HTTP session token and the PubNub instance). This is separate from `end()`, which is called internally after most API calls and only clears the HTTP token. Callers who want to tear down an August instance entirely should use `destroy()`.

Exports `tearDownPubNub(august)` from `subscribe.ts` for use by `destroy()`.

## :gear: Release Notes

PubNub subscriptions from `subscribe()` now properly release their underlying WebSocket connections and timers when the unsubscribe function is called. Consumers no longer accumulate orphaned PubNub instances across repeated subscribe/unsubscribe cycles.

A new `destroy()` method on the `August` class fully tears down an instance - clearing the session token and destroying any active PubNub subscriptions. Use this instead of `end()` when you want to release all resources associated with an August instance.

The behavior when no PubNub subscriptions exist is unchanged - only callers that actually use `subscribe()` see a difference.

## :heavy_plus_sign: Additional Information

### Testing

- New tests covering the redesigned behavior:

### Related

There is a companion PR to `homebridge-august` once this is merged, since there are related issues there. 