### PR TITLE
fix: use scoped undici dispatcher to prevent stale connection pool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
       ],
       "license": "ISC",
       "dependencies": {
-        "pubnub": "^10.2.9"
+        "pubnub": "^10.2.9",
+        "undici": "^8.1.0"
       },
       "devDependencies": {
         "@antfu/eslint-config": "^8.2.0",
@@ -9362,6 +9363,15 @@
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.1.0.tgz",
+      "integrity": "sha512-E9MkTS4xXLnRPYqxH2e6Hr2/49e7WFDKczKcCaFH4VaZs2iNvHMqeIkyUAD9vM8kujy9TjVrRlQ5KkdEJxB2pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "docs:lint": "typedoc --emit none --treatWarningsAsErrors"
   },
   "dependencies": {
-    "pubnub": "^10.2.9"
+    "pubnub": "^10.2.9",
+    "undici": "^8.1.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^8.2.0",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,9 +1,20 @@
 import type { config } from './types'
 
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { TimeoutError } from './exceptions'
-import August from './index'
+
+// Mock undici before importing August
+const mockFetch = vi.fn()
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('undici')>()
+  return {
+    ...actual,
+    fetch: mockFetch,
+  }
+})
+
+const { default: August } = await import('./index')
 
 describe('august', () => {
   const mockConfig: config = {
@@ -12,6 +23,10 @@ describe('august', () => {
     augustId: 'test@example.com',
     password: 'test-password',
   }
+
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
 
   it('should instantiate with config', () => {
     const august = new August(mockConfig)
@@ -38,9 +53,8 @@ describe('august', () => {
   it('should reject with TimeoutError when request exceeds timeout', async () => {
     const august = new August({ ...mockConfig, timeout: 50 })
 
-    // Mock global fetch to simulate a slow response that respects AbortSignal
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
-      (_url, init) => new Promise<Response>((_resolve, reject) => {
+    mockFetch.mockImplementation(
+      (_url: string, init: any) => new Promise<Response>((_resolve, reject) => {
         if (init?.signal) {
           init.signal.addEventListener('abort', () => {
             reject(new DOMException('The operation was aborted.', 'TimeoutError'))
@@ -49,125 +63,110 @@ describe('august', () => {
       }),
     )
 
-    try {
-      await expect(
-        august.fetch({ method: 'get', url: 'https://api-production.august.com/locks' }),
-      ).rejects.toThrow(TimeoutError)
-    } finally {
-      fetchSpy.mockRestore()
-    }
+    await expect(
+      august.fetch({ method: 'get', url: 'https://api-production.august.com/locks' }),
+    ).rejects.toThrow(TimeoutError)
   })
 
   it('should parse JSON response body', async () => {
     const august = new August(mockConfig)
     const mockBody = { lockId: 'abc123', status: 'locked' }
 
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    mockFetch.mockResolvedValue(
       new Response(JSON.stringify(mockBody), {
         status: 200,
         headers: { 'content-type': 'application/json' },
       }),
     )
 
-    try {
-      const result = await august.fetch({
-        method: 'get',
-        url: 'https://api-production.august.com/locks',
-      })
-      expect(result.body).toEqual(mockBody)
-    } finally {
-      fetchSpy.mockRestore()
-    }
+    const result = await august.fetch({
+      method: 'get',
+      url: 'https://api-production.august.com/locks',
+    })
+    expect(result.body).toEqual(mockBody)
   })
 
   it('should return headers as a plain object', async () => {
     const august = new August(mockConfig)
 
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    mockFetch.mockResolvedValue(
       new Response('{}', {
         status: 200,
         headers: { 'x-august-access-token': 'test-token-123' },
       }),
     )
 
-    try {
-      const result = await august.fetch({
-        method: 'post',
-        url: 'https://api-production.august.com/session',
-      })
-      expect(result.headers['x-august-access-token']).toBe('test-token-123')
-    } finally {
-      fetchSpy.mockRestore()
-    }
+    const result = await august.fetch({
+      method: 'post',
+      url: 'https://api-production.august.com/session',
+    })
+    expect(result.headers['x-august-access-token']).toBe('test-token-123')
   })
 
   it('should throw with statusCode on HTTP errors', async () => {
     const august = new August(mockConfig)
 
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    mockFetch.mockResolvedValue(
       new Response('Bad Gateway', { status: 502, statusText: 'Bad Gateway' }),
     )
 
-    try {
-      await expect(
-        august.fetch({ method: 'get', url: 'https://api-production.august.com/locks' }),
-      ).rejects.toMatchObject({ statusCode: 502 })
-    } finally {
-      fetchSpy.mockRestore()
-    }
+    await expect(
+      august.fetch({ method: 'get', url: 'https://api-production.august.com/locks' }),
+    ).rejects.toMatchObject({ statusCode: 502 })
   })
 
   it('should prepend base URL when path is relative', async () => {
     const august = new August(mockConfig)
 
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    mockFetch.mockResolvedValue(
       new Response('{}', { status: 200 }),
     )
 
-    try {
-      await august.fetch({ method: 'get', url: '/locks' })
-      expect(fetchSpy).toHaveBeenCalledWith(
-        'https://api-production.august.com/locks',
-        expect.any(Object),
-      )
-    } finally {
-      fetchSpy.mockRestore()
-    }
+    await august.fetch({ method: 'get', url: '/locks' })
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api-production.august.com/locks',
+      expect.any(Object),
+    )
   })
 
   it('should use non-US base URL for non-US country codes', async () => {
     const august = new August({ ...mockConfig, countryCode: 'GB' })
 
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    mockFetch.mockResolvedValue(
       new Response('{}', { status: 200 }),
     )
 
-    try {
-      await august.fetch({ method: 'get', url: '/locks' })
-      expect(fetchSpy).toHaveBeenCalledWith(
-        'https://api.aaecosystem.com/locks',
-        expect.any(Object),
-      )
-    } finally {
-      fetchSpy.mockRestore()
-    }
+    await august.fetch({ method: 'get', url: '/locks' })
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.aaecosystem.com/locks',
+      expect.any(Object),
+    )
   })
 
   it('should handle empty response body', async () => {
     const august = new August(mockConfig)
 
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    mockFetch.mockResolvedValue(
       new Response('', { status: 200 }),
     )
 
-    try {
-      const result = await august.fetch({
-        method: 'put',
-        url: 'https://api-production.august.com/remoteoperate/lock123/lock',
-      })
-      expect(result.body).toBeNull()
-    } finally {
-      fetchSpy.mockRestore()
-    }
+    const result = await august.fetch({
+      method: 'put',
+      url: 'https://api-production.august.com/remoteoperate/lock123/lock',
+    })
+    expect(result.body).toBeNull()
+  })
+
+  it('should pass scoped dispatcher to fetch', async () => {
+    const august = new August(mockConfig)
+
+    mockFetch.mockResolvedValue(
+      new Response('{}', { status: 200 }),
+    )
+
+    await august.fetch({ method: 'get', url: '/locks' })
+    const callArgs = mockFetch.mock.calls[0][1]
+    expect(callArgs.dispatcher).toBeDefined()
+    expect(callArgs.dispatcher).not.toBe(undefined)
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,13 @@
 import type { Brand } from './settings.js'
 import type { config } from './types.js'
 
-import { TimeoutError } from './exceptions.js'
 /* Copyright(C) 2024, homebridge-plugins (https://github.com/homebridge-plugins). All rights reserved.
  *
  * index.ts: august-yale API registration.
  */
+import { Agent, fetch as undiciFetch } from 'undici'
+
+import { TimeoutError } from './exceptions.js'
 import alarms, { alarmDevices, setAlarmState } from './methods/alarms.js'
 import lockAsync, { statusAsync, unlatchAsync, unlockAsync } from './methods/async-operations.js'
 import authorize from './methods/authorize.js'
@@ -46,8 +48,17 @@ interface ApiResponse {
 class August {
   config: config
   token: any
+  private dispatcher: Agent
   constructor(config: config) {
     this.config = setup(config)
+    // Each August instance owns its own connection pool.
+    // This prevents a corrupted global pool from permanently breaking
+    // all requests — if this instance's connections go bad, destroy()
+    // + new August() gives a completely fresh pool.
+    this.dispatcher = new Agent({
+      keepAliveTimeout: 30_000,
+      keepAliveMaxTimeout: 60_000,
+    })
   }
 
   async fetch({ method, url, headers, data }: FetchOptions): Promise<ApiResponse> {
@@ -72,25 +83,21 @@ class August {
 
     const timeoutMs = this.config.timeout ?? 30000
 
-    const init: RequestInit = {
-      method: method.toUpperCase(),
-      headers: headers as HeadersInit,
-      // AbortSignal.timeout() both rejects the promise AND aborts the
-      // underlying TCP connection, removing it from any connection pool.
-      // This is the key improvement over the previous tiny-json-http approach
-      // where the timeout only rejected the wrapping promise while the dead
-      // socket stayed in Node's global agent pool, causing all subsequent
-      // requests to write into the void.
-      signal: AbortSignal.timeout(timeoutMs),
-    }
-
-    if (data !== null && data !== undefined) {
-      init.body = JSON.stringify(data)
-    }
+    const requestBody = (data !== null && data !== undefined)
+      ? JSON.stringify(data)
+      : undefined
 
     let response: Response
     try {
-      response = await fetch(url, init)
+      response = await undiciFetch(url, {
+        method: method.toUpperCase(),
+        headers,
+        body: requestBody,
+        // AbortSignal.timeout() both rejects the promise AND aborts the
+        // underlying TCP connection, removing it from the scoped pool.
+        signal: AbortSignal.timeout(timeoutMs),
+        dispatcher: this.dispatcher,
+      }) as Response
     } catch (e: unknown) {
       // AbortSignal.timeout() throws a DOMException with name 'TimeoutError'
       if (e instanceof DOMException && e.name === 'TimeoutError') {
@@ -186,6 +193,7 @@ class August {
    */
   destroy() {
     this.token = null
+    this.dispatcher.close()
     tearDownPubNub(this)
   }
 


### PR DESCRIPTION
## :recycle: Current situation

After a network disruption (router restart, ISP blip), the global dispatcher's internal pool gets into a permanently broken state. All subsequent `fetch()` calls fail with "fetch failed" even though the network has fully recovered. `curl` works, a fresh Node process works, but the long-running homebridge process is stuck until manually restarted.

This is the same class of bug as the original `tiny-json-http` issue: **shared mutable connection state that can't self-heal.**

## :bulb: Proposed solution

Give each `August` instance its own `undici.Agent` as a scoped dispatcher. This eliminates all shared connection state:

- **Normal operation:** Connections are pooled within the instance (`keepAliveTimeout: 30s`) for efficient reuse during burst API calls (e.g. session + status in quick succession)
- **Network disruption:** If the pool goes bad, subsequent `fetch()` calls through the scoped pool open fresh connections automatically. No manual recovery needed for transient outages.
- **Instance replacement:** When homebridge-august creates a new `August` instance via session refresh, the new dispatcher starts completely clean — no poisoned global state to inherit
- **Cleanup:** `destroy()` closes the dispatcher along with PubNub subscriptions

## :gear: Changes

- **src/index.ts:** Import `Agent` and `fetch` from `undici`. Create a scoped `Agent` in the constructor, pass it as `dispatcher` to every `fetch()` call, close it in `destroy()`.
- **src/index.test.ts:** Mock the `undici` module instead of `globalThis.fetch`. Add test verifying the scoped dispatcher is passed to every request.
- **package.json:** Add `undici` as a dependency (Node 22 bundles it internally but doesn't expose it as an importable module).

## :heavy_plus_sign: Additional Information

### No changes needed in homebridge-august

### Testing

