### PR TITLE
Expose PubNub status events via onPubNubStatus()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import lockUnlock from './methods/lock-unlock.js'
 import locks from './methods/locks.js'
 import pins from './methods/pins.js'
 import status from './methods/status.js'
-import subscribe, { tearDownPubNub } from './methods/subscribe.js'
+import subscribe, { onPubNubStatus, tearDownPubNub } from './methods/subscribe.js'
 import unlatch from './methods/unlatch.js'
 import user from './methods/users.js'
 import validate from './methods/validate.js'
@@ -407,6 +407,24 @@ class August {
 
   async _subscribe(lockId: any, callback: any) {
     return subscribe.call(this, lockId, callback, true) // true keeps the session alive
+  }
+
+  /**
+   * Register a callback for PubNub status events. The callback receives
+   * the full PubNub status object — branch on `status.category` (e.g.
+   * `PNReconnectedCategory`, `PNNetworkDownCategory`).
+   *
+   * Returns an unsubscribe function. Safe to call before subscribe() —
+   * the listener will be wired to the PubNub instance the first time
+   * subscribe() creates it.
+   *
+   * Use case: connectivity-recovery detection. PubNub's WebSocket
+   * reconnects seconds before HTTP polling would notice that an
+   * outage has ended, so this is the fastest signal a homebridge
+   * plugin can use to decide it's safe to resume API calls.
+   */
+  onPubNubStatus(callback: (status: any) => void): () => void {
+    return onPubNubStatus(this, callback)
   }
 
   addSimpleProps(obj: { state?: any, lockID?: any, status?: any, doorState?: any, info?: any }) {

--- a/src/methods/subscribe.test.ts
+++ b/src/methods/subscribe.test.ts
@@ -31,6 +31,9 @@ vi.mock('pubnub', () => {
         _simulateMessage: (event: any) => {
           listeners.forEach(l => l.message?.(event))
         },
+        _simulateStatus: (status: any) => {
+          listeners.forEach(l => l.status?.(status))
+        },
       }
       mockPubNubInstances.push(instance)
       return instance
@@ -40,7 +43,7 @@ vi.mock('pubnub', () => {
 
 const subscribeModule = await import('./subscribe')
 const subscribe = subscribeModule.default
-const { tearDownPubNub } = subscribeModule
+const { tearDownPubNub, onPubNubStatus } = subscribeModule
 
 function makeFakeAugust(options: { lockIds?: string[], pubsubChannels?: Record<string, string> } = {}) {
   const lockIds = options.lockIds ?? ['lock-1']
@@ -277,5 +280,116 @@ describe('subscribe method - tearDownPubNub', () => {
     tearDownPubNub(august)
 
     expect(pn.destroy).toHaveBeenCalledOnce()
+  })
+})
+
+describe('onPubNubStatus', () => {
+  it('delivers status events to a listener registered AFTER subscribe()', async () => {
+    const august = makeFakeAugust()
+    await subscribe.call(august, 'lock-1', vi.fn(), false)
+    const pn = mockPubNubInstances[mockPubNubInstances.length - 1]
+
+    const listener = vi.fn()
+    onPubNubStatus(august, listener)
+
+    pn._simulateStatus({ category: 'PNReconnectedCategory' })
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(listener).toHaveBeenCalledWith({ category: 'PNReconnectedCategory' })
+  })
+
+  it('delivers status events to a listener registered BEFORE subscribe()', async () => {
+    // Use case from homebridge-august: register the listener at platform
+    // init time, before any lock has called subscribe(). The listener
+    // must still see events when subscribe() eventually creates the
+    // PubNub instance.
+    const august = makeFakeAugust()
+    const listener = vi.fn()
+    onPubNubStatus(august, listener)
+
+    await subscribe.call(august, 'lock-1', vi.fn(), false)
+    const pn = mockPubNubInstances[mockPubNubInstances.length - 1]
+    pn._simulateStatus({ category: 'PNConnectedCategory' })
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('delivers events to all registered listeners', async () => {
+    const august = makeFakeAugust()
+    await subscribe.call(august, 'lock-1', vi.fn(), false)
+    const pn = mockPubNubInstances[mockPubNubInstances.length - 1]
+
+    const a = vi.fn()
+    const b = vi.fn()
+    onPubNubStatus(august, a)
+    onPubNubStatus(august, b)
+
+    pn._simulateStatus({ category: 'PNReconnectedCategory' })
+    expect(a).toHaveBeenCalledTimes(1)
+    expect(b).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns an unsubscribe function that removes only that listener', async () => {
+    const august = makeFakeAugust()
+    await subscribe.call(august, 'lock-1', vi.fn(), false)
+    const pn = mockPubNubInstances[mockPubNubInstances.length - 1]
+
+    const a = vi.fn()
+    const b = vi.fn()
+    const unsubscribeA = onPubNubStatus(august, a)
+    onPubNubStatus(august, b)
+
+    unsubscribeA()
+    pn._simulateStatus({ category: 'PNReconnectedCategory' })
+
+    expect(a).not.toHaveBeenCalled()
+    expect(b).toHaveBeenCalledTimes(1)
+  })
+
+  it('unsubscribe is idempotent', async () => {
+    const august = makeFakeAugust()
+    await subscribe.call(august, 'lock-1', vi.fn(), false)
+    const pn = mockPubNubInstances[mockPubNubInstances.length - 1]
+
+    const a = vi.fn()
+    const unsubscribe = onPubNubStatus(august, a)
+    unsubscribe()
+    unsubscribe() // second call is a no-op
+
+    pn._simulateStatus({ category: 'PNReconnectedCategory' })
+    expect(a).not.toHaveBeenCalled()
+  })
+
+  it('a throwing listener does not block other listeners', async () => {
+    const august = makeFakeAugust()
+    await subscribe.call(august, 'lock-1', vi.fn(), false)
+    const pn = mockPubNubInstances[mockPubNubInstances.length - 1]
+
+    const good = vi.fn()
+    onPubNubStatus(august, () => { throw new Error('listener bug') })
+    onPubNubStatus(august, good)
+
+    expect(() => pn._simulateStatus({ category: 'PNReconnectedCategory' })).not.toThrow()
+    expect(good).toHaveBeenCalledTimes(1)
+  })
+
+  it('tearDownPubNub clears status listeners', async () => {
+    const august = makeFakeAugust()
+    await subscribe.call(august, 'lock-1', vi.fn(), false)
+    const pn = mockPubNubInstances[mockPubNubInstances.length - 1]
+
+    const a = vi.fn()
+    onPubNubStatus(august, a)
+    tearDownPubNub(august)
+
+    // The mock's _simulateStatus iterates the listener list pn carries;
+    // after tearDownPubNub, removeAllListeners() emptied pn._listeners,
+    // so the status callback won't be invoked anyway. But the contract
+    // we care about is: after teardown, even if a NEW pubnub instance
+    // is created (a fresh subscribe call), the previous listener must
+    // not still be wired up.
+    await subscribe.call(august, 'lock-1', vi.fn(), false)
+    const pn2 = mockPubNubInstances[mockPubNubInstances.length - 1]
+    expect(pn2).not.toBe(pn)
+    pn2._simulateStatus({ category: 'PNReconnectedCategory' })
+    expect(a).not.toHaveBeenCalled()
   })
 })

--- a/src/methods/subscribe.ts
+++ b/src/methods/subscribe.ts
@@ -18,6 +18,47 @@ interface PubNubState {
 const instanceState = new WeakMap<object, PubNubState>()
 
 /**
+ * Per-August-instance PubNub status listeners. Separate from PubNubState
+ * because status listeners can be registered before subscribe() has
+ * created the PubNub instance — homebridge plugins typically want to
+ * react to PubNub reconnect events as a connectivity-recovery signal,
+ * which means hooking listeners up at platform-init time, not lock-by-lock.
+ *
+ * Stored in their own WeakMap keyed on the August instance so they
+ * survive across multiple subscribe() calls and clear automatically
+ * when the August instance is GC'd.
+ */
+const statusListeners = new WeakMap<object, Set<(status: any) => void>>()
+
+/**
+ * Register a callback for PubNub status events on this August instance.
+ *
+ * The callback receives the full PubNub status object; callers typically
+ * branch on `status.category` (e.g. `PNReconnectedCategory`,
+ * `PNNetworkDownCategory`). Returns an idempotent unsubscribe function.
+ *
+ * Safe to call before subscribe() has been invoked. The listener will
+ * be wired to the shared PubNub instance the first time subscribe()
+ * creates it.
+ */
+export function onPubNubStatus(august: object, cb: (status: any) => void): () => void {
+  let set = statusListeners.get(august)
+  if (!set) {
+    set = new Set()
+    statusListeners.set(august, set)
+  }
+  set.add(cb)
+  let unsubscribed = false
+  return () => {
+    if (unsubscribed) {
+      return
+    }
+    unsubscribed = true
+    statusListeners.get(august)?.delete(cb)
+  }
+}
+
+/**
  * Tear down the PubNub instance associated with this August instance.
  * Called when no subscriptions remain, or externally via cleanup paths.
  */
@@ -34,6 +75,7 @@ export function tearDownPubNub(august: object): void {
     // Best-effort cleanup; swallow any errors during teardown
   }
   instanceState.delete(august)
+  statusListeners.delete(august)
 }
 
 /**
@@ -117,6 +159,27 @@ export default async function subscribe(
         }
         for (const cb of callbacks) {
           cb(message, timetoken)
+        }
+      },
+      // PubNub status events. Dispatch to listeners registered via
+      // onPubNubStatus(). The full status object is passed through —
+      // consumers typically branch on `status.category` (e.g.
+      // PNConnectedCategory, PNReconnectedCategory, PNNetworkDownCategory).
+      // This is the fastest signal that the underlying network has
+      // recovered after a transient outage; the WebSocket reconnects
+      // seconds before HTTP polling would notice.
+      status: (status: any) => {
+        const listeners = statusListeners.get(this)
+        if (!listeners) {
+          return
+        }
+        for (const cb of listeners) {
+          try {
+            cb(status)
+          } catch {
+            // Best-effort: do not let one listener's exception block
+            // delivery to others.
+          }
         }
       },
     })


### PR DESCRIPTION
## :recycle: Current situation

august-yale's `subscribe()` wires up the PubNub `message:` handler
internally but doesn't surface `status:` events to consumers. The
PubNub instance itself isn't reachable from outside the module either,
so there's no way for a downstream plugin to react to WebSocket
connection-state changes (`PNConnectedCategory`,
`PNReconnectedCategory`, `PNNetworkDownCategory`, etc).

I'm hitting this in homebridge-august, where I want to use a PubNub
reconnect as a fast "network is back" signal during recovery from a
router restart - the WebSocket reconnects ~5–10 seconds before HTTP
polling would notice.

## :bulb: Proposed solution

A new method on the August class:

```ts
august.onPubNubStatus(callback: (status) => void): () => void
```

Returns an unsubscribe function. Listeners can be registered before
`subscribe()` has constructed the PubNub instance — they're stored in
their own WeakMap (separate from the existing `instanceState`) and
attached when the shared `addListener({...})` call is made. That
matters for downstream plugins that want to register at platform-init
time rather than per-lock.

## :gear: Release Notes

New API: `August.onPubNubStatus(callback)`. Pass a function; receive an
unsubscribe function. The callback fires for every PubNub status event
on the underlying WebSocket — branch on `status.category`. No breaking
changes; no impact on existing consumers.

## :heavy_plus_sign: Additional Information

Prerequisite for a homebridge-august connectivity-recovery fix that
I'll open separately once a new august-yale version with this method
is published. Happy to adjust the API shape (name, signature,
location) if you'd prefer something different.

### Testing

7 new specs in `src/methods/subscribe.test.ts`

### Reviewer Nudging

