### PR TITLE
fix: support Node 20, undici 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       "license": "ISC",
       "dependencies": {
         "pubnub": "^10.2.9",
-        "undici": "^8.1.0"
+        "undici": "^7.25.0"
       },
       "devDependencies": {
         "@antfu/eslint-config": "^8.2.0",
@@ -33,7 +33,7 @@
         "vitest": "^4.1.4"
       },
       "engines": {
-        "node": "^22 || ^24"
+        "node": "^20.18.1 || ^22 || ^24"
       }
     },
     "node_modules/@antfu/eslint-config": {
@@ -1121,9 +1121,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1141,9 +1138,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1161,9 +1155,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1181,9 +1172,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1201,9 +1189,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1221,9 +1206,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1241,9 +1223,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1261,9 +1240,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1610,9 +1586,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1630,9 +1603,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1650,9 +1620,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1670,9 +1637,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1690,9 +1654,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1710,9 +1671,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5809,9 +5767,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5833,9 +5788,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5857,9 +5809,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5881,9 +5830,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9185,12 +9131,12 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.1.0.tgz",
-      "integrity": "sha512-E9MkTS4xXLnRPYqxH2e6Hr2/49e7WFDKczKcCaFH4VaZs2iNvHMqeIkyUAD9vM8kujy9TjVrRlQ5KkdEJxB2pw==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=22.19.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "main": "dist/index.js",
   "engines": {
-    "node": "^22 || ^24"
+    "node": "^20.18.1 || ^22 || ^24"
   },
   "scripts": {
     "check": "npm install && npm outdated",
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "pubnub": "^10.2.9",
-    "undici": "^8.1.0"
+    "undici": "^7.25.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^8.2.0",

--- a/src/methods/subscribe.test.ts
+++ b/src/methods/subscribe.test.ts
@@ -364,7 +364,9 @@ describe('onPubNubStatus', () => {
     const pn = mockPubNubInstances[mockPubNubInstances.length - 1]
 
     const good = vi.fn()
-    onPubNubStatus(august, () => { throw new Error('listener bug') })
+    onPubNubStatus(august, () => {
+      throw new Error('listener bug')
+    })
     onPubNubStatus(august, good)
 
     expect(() => pn._simulateStatus({ category: 'PNReconnectedCategory' })).not.toThrow()


### PR DESCRIPTION
## :recycle: Current situation

CI on PR #40 failed on Node 20 with:

    TypeError: webidl.util.markAsUncloneable is not a function

undici 8 declares `engines.node >=22.19.0` because it uses
`webidl.util.markAsUncloneable`, which only exists in Node 22+. With
undici 8 in `dependencies`, the library was effectively Node 22+ only
at runtime as well - Node 20 users would have hit the same crash on
import.

## :bulb: Proposed solution

Pin undici to `^7.25.0` (which supports Node >=20.18.1) and broaden
`engines.node` to `"^20.18.1 || ^22 || ^24"`.

august-yale only uses undici's `Agent`, `fetch`, and `Response` type —
all stable across the 7→8 boundary, so no source changes are needed.

Also expand the inline arrow body in `subscribe.test.ts` to multi-line
form to fix the lint error.

## :gear: Release Notes

Restores Node 20 support. No API changes; users on Node 20.18.1+ can
now use the library.

## :heavy_plus_sign: Additional Information

### Testing

Verified locally: lint clean, build clean, tests pass.

### Reviewer Nudging

