### PR TITLE
feat: typed transport-error wrapper (NetworkError, AbortedError)

### DIFF
--- a/src/exceptions.test.ts
+++ b/src/exceptions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { BridgeError, InvalidAuth, RateLimitError, TimeoutError, YaleApiError } from './exceptions.js'
+import { AbortedError, BridgeError, InvalidAuth, NetworkError, RateLimitError, TimeoutError, YaleApiError } from './exceptions.js'
 
 describe('exceptions', () => {
   it('should create YaleApiError correctly', () => {
@@ -45,6 +45,49 @@ describe('exceptions', () => {
     expect(error).toBeInstanceOf(TimeoutError)
     expect(error.message).toBe('Request timeout')
     expect(error.name).toBe('TimeoutError')
+  })
+
+  it('should create NetworkError correctly', () => {
+    const error = new NetworkError('Network down')
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toBeInstanceOf(YaleApiError)
+    expect(error).toBeInstanceOf(NetworkError)
+    expect(error.message).toBe('Network down')
+    expect(error.name).toBe('NetworkError')
+  })
+
+  it('networkError carries a code when supplied', () => {
+    const error = new NetworkError('Connect timeout', undefined, 'UND_ERR_CONNECT_TIMEOUT')
+    expect(error.code).toBe('UND_ERR_CONNECT_TIMEOUT')
+  })
+
+  it('timeoutError is also a NetworkError (back-compat with broader catches)', () => {
+    // After making TimeoutError extend NetworkError, every TimeoutError
+    // should match `instanceof NetworkError` so consumers using the
+    // broader catch see it.
+    const error = new TimeoutError('Connect timed out')
+    expect(error).toBeInstanceOf(NetworkError)
+    expect(error).toBeInstanceOf(YaleApiError)
+  })
+
+  it('should create AbortedError correctly', () => {
+    const error = new AbortedError('aborted')
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toBeInstanceOf(YaleApiError)
+    expect(error).toBeInstanceOf(AbortedError)
+    expect(error.message).toBe('aborted')
+    expect(error.name).toBe('AbortedError')
+    // AbortedError is intentionally NOT a NetworkError — consumers
+    // catching NetworkError to handle "transport failure, retry" should
+    // not also catch intentional teardowns.
+    expect(error).not.toBeInstanceOf(NetworkError)
+  })
+
+  it('preserves originalError and exposes it via cause', () => {
+    const inner = new Error('inner')
+    const wrapped = new NetworkError('outer', inner, 'ECONNRESET')
+    expect(wrapped.originalError).toBe(inner)
+    expect((wrapped as any).cause).toBe(inner)
   })
 
   it('should preserve original error', () => {

--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -64,15 +64,80 @@ export class BridgeError extends YaleApiError {
 }
 
 /**
- * Timeout error class
+ * Network / transport-level failure.
+ *
+ * Thrown when a request did not get a clean answer from the server: TCP
+ * connect timeout, socket reset, DNS failure, headers/body timeout,
+ * malformed response, TLS proxy failure, etc. Distinct from
+ * {@link InvalidAuth} (server answered with 401) and from generic
+ * server errors (server answered with 4xx/5xx HTTP, see
+ * {@link YaleApiError}).
+ *
+ * Consumers can check `err.code` for the underlying transport code
+ * (e.g. `ECONNRESET`, `UND_ERR_CONNECT_TIMEOUT`). The original error
+ * is preserved on `err.cause` and `err.originalError`.
  */
-export class TimeoutError extends YaleApiError {
-  constructor(message: string, originalError?: Error) {
+export class NetworkError extends YaleApiError {
+  /** Underlying transport error code, when available. */
+  public code?: string
+
+  constructor(message: string, originalError?: Error, code?: string) {
     super(message, originalError)
+    this.name = 'NetworkError'
+    this.code = code
+    if (originalError) {
+      // Preserve cause for code that walks the chain.
+      ;(this as any).cause = originalError
+    }
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, NetworkError)
+    }
+  }
+}
+
+/**
+ * Timeout error class.
+ *
+ * Subclass of {@link NetworkError} — a request timing out is one
+ * specific kind of transport-level failure. Existing callers checking
+ * `err instanceof TimeoutError` continue to work; callers using the
+ * broader `err instanceof NetworkError` (or `instanceof YaleApiError`)
+ * also catch this case.
+ */
+export class TimeoutError extends NetworkError {
+  constructor(message: string, originalError?: Error, code?: string) {
+    super(message, originalError, code)
     this.name = 'TimeoutError'
 
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, TimeoutError)
+    }
+  }
+}
+
+/**
+ * Aborted error.
+ *
+ * Thrown when an in-flight request races with an intentional client
+ * teardown (e.g. the consumer calling `august.destroy()` while requests
+ * are pending). Callers should typically swallow these — they reflect
+ * the consumer's own intent, not a real failure.
+ */
+export class AbortedError extends YaleApiError {
+  /** Underlying transport error code, when available. */
+  public code?: string
+
+  constructor(message: string, originalError?: Error, code?: string) {
+    super(message, originalError)
+    this.name = 'AbortedError'
+    this.code = code
+    if (originalError) {
+      ;(this as any).cause = originalError
+    }
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, AbortedError)
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,11 +27,12 @@ import user from './methods/users.js'
 import validate from './methods/validate.js'
 import addWebSocketSubscription, { deleteWebSocketSubscription, getWebSocketSubscriptions } from './methods/websocket.js'
 import { BASE_URLS } from './settings.js'
+import { classifyTransportError } from './util/classify-error.js'
 import session from './util/session.js'
 import setup from './util/setup.js'
 
 // Export exceptions for external use
-export { BridgeError, InvalidAuth, RateLimitError, TimeoutError, YaleApiError } from './exceptions.js'
+export { AbortedError, BridgeError, InvalidAuth, NetworkError, RateLimitError, TimeoutError, YaleApiError } from './exceptions.js'
 export { Brand } from './settings.js'
 
 interface FetchOptions {
@@ -101,9 +102,21 @@ class August {
         dispatcher: this.dispatcher,
       }) as UndiciResponse
     } catch (e: unknown) {
-      // AbortSignal.timeout() throws a DOMException with name 'TimeoutError'
+      // AbortSignal.timeout() throws a DOMException with name 'TimeoutError'.
+      // We classify this as our own TimeoutError so consumers don't have
+      // to special-case DOMException semantics.
       if (e instanceof DOMException && e.name === 'TimeoutError') {
-        throw new TimeoutError(`Request timed out after ${timeoutMs}ms`)
+        throw new TimeoutError(`Request timed out after ${timeoutMs}ms`, e instanceof Error ? e : undefined)
+      }
+      // Classify other transport-level failures into NetworkError /
+      // TimeoutError / AbortedError. The original error is preserved on
+      // both `originalError` and `cause`, so consumers walking the cause
+      // chain continue to work. Programmer errors (InvalidArgumentError,
+      // etc.) and server-answered errors return null and bubble up
+      // unchanged.
+      const wrapped = classifyTransportError(e)
+      if (wrapped) {
+        throw wrapped
       }
       throw e
     }

--- a/src/util/classify-error.test.ts
+++ b/src/util/classify-error.test.ts
@@ -1,0 +1,216 @@
+/* Copyright(C) 2026, homebridge-plugins (https://github.com/homebridge-plugins). All rights reserved.
+ *
+ * classify-error.test.ts: tests for transport-error classification.
+ *
+ * The shapes covered here mirror the actual undici 7.x error taxonomy
+ * (see node_modules/undici/lib/core/errors.js). Each named undici error
+ * class is tested by constructing the equivalent shape — that's what
+ * the consumer actually sees, regardless of whether the constructor
+ * details change in a future undici release.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { AbortedError, NetworkError, TimeoutError } from '../exceptions.js'
+import { classifyTransportError } from './classify-error.js'
+
+// Helper: simulate undici's pattern of wrapping every fetch failure in
+// `TypeError("fetch failed")` with the real cause attached.
+function fetchFailedWith(cause: any): TypeError {
+  const err = new TypeError('fetch failed') as any
+  err.cause = cause
+  return err
+}
+
+// Helper: build an error with a name and code, mirroring undici classes.
+function namedErrorWithCode(name: string, code: string, message = name): Error {
+  const err = new Error(message) as any
+  err.name = name
+  err.code = code
+  return err
+}
+
+describe('classifyTransportError', () => {
+  describe('undici timeout family', () => {
+    it('classifies wrapped ConnectTimeoutError (UND_ERR_CONNECT_TIMEOUT) as TimeoutError', () => {
+      // This is the exact shape from a real production failure log:
+      // TypeError "fetch failed" wrapping ConnectTimeoutError.
+      const wrapped = fetchFailedWith(
+        namedErrorWithCode('ConnectTimeoutError', 'UND_ERR_CONNECT_TIMEOUT', 'Connect Timeout Error'),
+      )
+      const result = classifyTransportError(wrapped)
+      expect(result).toBeInstanceOf(TimeoutError)
+      expect(result).toBeInstanceOf(NetworkError) // back-compat
+      expect(result?.code).toBe('UND_ERR_CONNECT_TIMEOUT')
+      expect(result?.originalError).toBe(wrapped)
+    })
+
+    it('classifies HeadersTimeoutError (UND_ERR_HEADERS_TIMEOUT) as TimeoutError', () => {
+      const wrapped = fetchFailedWith(
+        namedErrorWithCode('HeadersTimeoutError', 'UND_ERR_HEADERS_TIMEOUT'),
+      )
+      expect(classifyTransportError(wrapped)).toBeInstanceOf(TimeoutError)
+    })
+
+    it('classifies BodyTimeoutError (UND_ERR_BODY_TIMEOUT) as TimeoutError', () => {
+      const wrapped = fetchFailedWith(
+        namedErrorWithCode('BodyTimeoutError', 'UND_ERR_BODY_TIMEOUT'),
+      )
+      expect(classifyTransportError(wrapped)).toBeInstanceOf(TimeoutError)
+    })
+  })
+
+  describe('undici generic transport failures', () => {
+    it('classifies SocketError (UND_ERR_SOCKET) as NetworkError', () => {
+      const wrapped = fetchFailedWith(
+        namedErrorWithCode('SocketError', 'UND_ERR_SOCKET'),
+      )
+      const result = classifyTransportError(wrapped)
+      expect(result).toBeInstanceOf(NetworkError)
+      expect(result).not.toBeInstanceOf(TimeoutError) // not a timeout
+      expect(result?.code).toBe('UND_ERR_SOCKET')
+    })
+
+    it('classifies HeadersOverflowError as NetworkError', () => {
+      const wrapped = fetchFailedWith(
+        namedErrorWithCode('HeadersOverflowError', 'UND_ERR_HEADERS_OVERFLOW'),
+      )
+      expect(classifyTransportError(wrapped)).toBeInstanceOf(NetworkError)
+    })
+
+    it('classifies SecureProxyConnectionError as NetworkError', () => {
+      const wrapped = fetchFailedWith(
+        namedErrorWithCode('SecureProxyConnectionError', 'UND_ERR_PRX_TLS'),
+      )
+      expect(classifyTransportError(wrapped)).toBeInstanceOf(NetworkError)
+    })
+  })
+
+  describe('undici lifecycle errors (intentional teardown)', () => {
+    it('classifies ClientDestroyedError as AbortedError, NOT NetworkError', () => {
+      // This is critical: when the consumer destroys the Agent (e.g.
+      // during a connectivity-rebuild cycle), in-flight requests reject
+      // with ClientDestroyedError. The consumer's intent was to tear
+      // down — it should NOT be reported as a network failure.
+      const wrapped = fetchFailedWith(
+        namedErrorWithCode('ClientDestroyedError', 'UND_ERR_DESTROYED'),
+      )
+      const result = classifyTransportError(wrapped)
+      expect(result).toBeInstanceOf(AbortedError)
+      expect(result).not.toBeInstanceOf(NetworkError)
+    })
+
+    it('classifies ClientClosedError as AbortedError', () => {
+      const wrapped = fetchFailedWith(
+        namedErrorWithCode('ClientClosedError', 'UND_ERR_CLOSED'),
+      )
+      expect(classifyTransportError(wrapped)).toBeInstanceOf(AbortedError)
+    })
+
+    it('classifies RequestAbortedError as AbortedError', () => {
+      const wrapped = fetchFailedWith(
+        namedErrorWithCode('AbortError', 'UND_ERR_ABORTED'),
+      )
+      expect(classifyTransportError(wrapped)).toBeInstanceOf(AbortedError)
+    })
+  })
+
+  describe('pOSIX socket errors (bare or wrapped)', () => {
+    it('classifies bare ECONNRESET as NetworkError', () => {
+      const err = namedErrorWithCode('Error', 'ECONNRESET', 'socket hang up')
+      expect(classifyTransportError(err)).toBeInstanceOf(NetworkError)
+    })
+
+    it('classifies wrapped ECONNRESET as NetworkError', () => {
+      const wrapped = fetchFailedWith(namedErrorWithCode('Error', 'ECONNRESET'))
+      expect(classifyTransportError(wrapped)).toBeInstanceOf(NetworkError)
+    })
+
+    it('classifies bare ETIMEDOUT as TimeoutError', () => {
+      const err = namedErrorWithCode('Error', 'ETIMEDOUT', 'connect ETIMEDOUT')
+      expect(classifyTransportError(err)).toBeInstanceOf(TimeoutError)
+    })
+
+    it('classifies bare ENOTFOUND as NetworkError', () => {
+      const err = namedErrorWithCode('Error', 'ENOTFOUND', 'getaddrinfo failed')
+      expect(classifyTransportError(err)).toBeInstanceOf(NetworkError)
+    })
+  })
+
+  describe('hTTP parser failures', () => {
+    it('classifies HPE_* coded errors as NetworkError', () => {
+      // libhttp-parser reports wire-level parse failures with codes
+      // prefixed HPE_ rather than the UND_ERR_ convention.
+      const err = namedErrorWithCode('HTTPParserError', 'HPE_INVALID_VERSION')
+      expect(classifyTransportError(err)).toBeInstanceOf(NetworkError)
+    })
+  })
+
+  describe('non-transport errors must NOT be wrapped', () => {
+    it('returns null for InvalidArgumentError (programmer bug)', () => {
+      // These are bugs — wrapping them as NetworkError would fool the
+      // state machine into retrying a deterministic failure forever.
+      const err = namedErrorWithCode('InvalidArgumentError', 'UND_ERR_INVALID_ARG')
+      expect(classifyTransportError(err)).toBeNull()
+    })
+
+    it('returns null for NotSupportedError (configuration bug)', () => {
+      const err = namedErrorWithCode('NotSupportedError', 'UND_ERR_NOT_SUPPORTED')
+      expect(classifyTransportError(err)).toBeNull()
+    })
+
+    it('returns null for plain server-answered errors with statusCode', () => {
+      // A 422 response is not a transport error — the server answered.
+      // Caller-level code should handle it; the classifier leaves it alone.
+      const err = Object.assign(new Error('Unprocessable Entity'), { statusCode: 422 })
+      expect(classifyTransportError(err)).toBeNull()
+    })
+
+    it('returns null for arbitrary unrelated errors', () => {
+      // A pure Error with no recognized code/name and no cause chain
+      // signals nothing transport-level — leave it alone.
+      expect(classifyTransportError(new Error('something'))).toBeNull()
+    })
+
+    it('returns null for non-Error throws', () => {
+      // Defensive: if someone throws a string or number, we should not
+      // wrap it as a NetworkError.
+      expect(classifyTransportError('a string')).toBeNull()
+      expect(classifyTransportError(42)).toBeNull()
+      expect(classifyTransportError(null)).toBeNull()
+      expect(classifyTransportError(undefined)).toBeNull()
+    })
+  })
+
+  describe('cause chain walking', () => {
+    it('walks cause chains up to depth 5', () => {
+      // Build a 5-deep chain ending in a recognized network code.
+      let cur: any = namedErrorWithCode('Error', 'ECONNRESET')
+      for (let i = 0; i < 4; i++) {
+        cur = Object.assign(new Error(`level ${i}`), { cause: cur })
+      }
+      expect(classifyTransportError(cur)).toBeInstanceOf(NetworkError)
+    })
+
+    it('does not infinite-loop on cyclic cause chains', () => {
+      const a: any = new Error('a')
+      const b: any = new Error('b')
+      a.cause = b
+      b.cause = a
+      // Should not crash; should return null since there's no recognized
+      // code anywhere in the (capped) chain.
+      expect(() => classifyTransportError(a)).not.toThrow()
+      expect(classifyTransportError(a)).toBeNull()
+    })
+  })
+
+  describe('preserves the original error', () => {
+    it('exposes the original via originalError and cause', () => {
+      const inner = namedErrorWithCode('ConnectTimeoutError', 'UND_ERR_CONNECT_TIMEOUT')
+      const wrapped = fetchFailedWith(inner)
+      const result = classifyTransportError(wrapped)
+      expect(result).not.toBeNull()
+      expect(result!.originalError).toBe(wrapped)
+      expect((result! as any).cause).toBe(wrapped)
+    })
+  })
+})

--- a/src/util/classify-error.ts
+++ b/src/util/classify-error.ts
@@ -1,0 +1,203 @@
+/* Copyright(C) 2026, homebridge-plugins (https://github.com/homebridge-plugins). All rights reserved.
+ *
+ * classify-error.ts: Map a transport-level exception (typically thrown
+ * by undici's fetch) into one of august-yale's typed exception classes.
+ *
+ * The 24-class undici taxonomy (see node_modules/undici/lib/core/errors.js)
+ * splits roughly into four categories:
+ *
+ *   1. Transport failures — connect timeout, socket reset, headers/body
+ *      timeout, DNS failure, malformed response, etc. These are
+ *      recoverable by retrying after a wait. They become NetworkError
+ *      (or TimeoutError, a subclass, for the timeout-specific cases).
+ *
+ *   2. Lifecycle errors — ClientDestroyedError, ClientClosedError,
+ *      RequestAbortedError. These reflect the consumer's own intent
+ *      (calling destroy() on the Agent, aborting via AbortController).
+ *      They become AbortedError. Consumers typically swallow them.
+ *
+ *   3. Programmer errors — InvalidArgumentError, NotSupportedError,
+ *      RequestContentLengthMismatchError. These are bugs that retrying
+ *      will not fix. They are NOT wrapped: the original error bubbles
+ *      up unchanged so the bug is visible.
+ *
+ *   4. Server-answered errors — ResponseError (4xx/5xx with body),
+ *      RequestRetryError. These have a statusCode and represent the
+ *      server's reply, not a transport issue. They are NOT wrapped
+ *      here — auth-specific handling lives in session.ts and the rest
+ *      bubble up as the original error.
+ *
+ * Callers who walk err.cause continue to find the original error
+ * unchanged. The wrapping is purely additive.
+ */
+
+import { AbortedError, NetworkError, TimeoutError } from '../exceptions.js'
+
+/**
+ * undici error codes that indicate a transport-level failure.
+ * Source: node_modules/undici/lib/core/errors.js classes whose `.code`
+ * starts with `UND_ERR_` and whose semantic is "request did not get a
+ * clean answer from the server".
+ */
+const UNDICI_NETWORK_CODES: ReadonlySet<string> = new Set([
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+  'UND_ERR_SOCKET',
+  'UND_ERR_HEADERS_OVERFLOW',
+  'UND_ERR_RES_EXCEEDED_MAX_SIZE',
+  'UND_ERR_PRX_TLS',
+  'UND_ERR_SOCKS5',
+  'UND_ERR_RES_CONTENT_LENGTH_MISMATCH',
+])
+
+/**
+ * undici error codes that specifically indicate a timeout.
+ * Subset of UNDICI_NETWORK_CODES; these become TimeoutError instead of
+ * the more general NetworkError.
+ */
+const UNDICI_TIMEOUT_CODES: ReadonlySet<string> = new Set([
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+])
+
+/**
+ * undici error codes raised when an in-flight request races with an
+ * intentional client teardown.
+ */
+const UNDICI_LIFECYCLE_CODES: ReadonlySet<string> = new Set([
+  'UND_ERR_DESTROYED',
+  'UND_ERR_CLOSED',
+  'UND_ERR_ABORTED',
+  'UND_ERR_ABORT',
+])
+
+/**
+ * POSIX socket error codes that indicate a transport-level failure.
+ * These appear on the underlying error when undici surfaces them via
+ * err.cause.code, or directly on bare Node http errors.
+ */
+const POSIX_NETWORK_CODES: ReadonlySet<string> = new Set([
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ECONNABORTED',
+  'ENETUNREACH',
+  'ENETDOWN',
+  'ENETRESET',
+  'EHOSTUNREACH',
+  'EHOSTDOWN',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'ETIMEDOUT',
+  'EPIPE',
+  'ENOTCONN',
+  'ESHUTDOWN',
+])
+
+/**
+ * POSIX codes whose semantic is specifically "timeout".
+ */
+const POSIX_TIMEOUT_CODES: ReadonlySet<string> = new Set([
+  'ETIMEDOUT',
+])
+
+/**
+ * Walk the err.cause chain up to a small depth, returning every error
+ * encountered. Capped to defend against pathological cycles.
+ */
+function flattenCauseChain(e: unknown): any[] {
+  const chain: any[] = []
+  let cur: any = e
+  let depth = 0
+  while (cur && depth < 5) {
+    chain.push(cur)
+    cur = cur.cause
+    depth++
+  }
+  return chain
+}
+
+interface ErrorMatch {
+  /** The error in the cause chain that matched a known shape. */
+  match: any
+  /** What kind of error it is. */
+  kind: 'timeout' | 'network' | 'aborted'
+}
+
+/**
+ * Inspect the cause chain and return the first error whose shape
+ * indicates a transport-level outcome (timeout, generic network,
+ * or aborted). Returns null if no match — caller should leave the
+ * original error untouched.
+ */
+function findTransportError(e: unknown): ErrorMatch | null {
+  for (const err of flattenCauseChain(e)) {
+    const code: string | undefined = typeof err?.code === 'string' ? err.code : undefined
+    const name: string | undefined = typeof err?.name === 'string' ? err.name : undefined
+
+    // Lifecycle: aborted / destroyed / closed.
+    if (code && UNDICI_LIFECYCLE_CODES.has(code)) {
+      return { match: err, kind: 'aborted' }
+    }
+    if (name === 'AbortError') {
+      return { match: err, kind: 'aborted' }
+    }
+
+    // Timeout-specific transport errors.
+    if (code && UNDICI_TIMEOUT_CODES.has(code)) {
+      return { match: err, kind: 'timeout' }
+    }
+    if (code && POSIX_TIMEOUT_CODES.has(code)) {
+      return { match: err, kind: 'timeout' }
+    }
+    if (name === 'ConnectTimeoutError' || name === 'HeadersTimeoutError' || name === 'BodyTimeoutError') {
+      return { match: err, kind: 'timeout' }
+    }
+
+    // Generic network transport errors.
+    if (code && UNDICI_NETWORK_CODES.has(code)) {
+      return { match: err, kind: 'network' }
+    }
+    if (code && POSIX_NETWORK_CODES.has(code)) {
+      return { match: err, kind: 'network' }
+    }
+    // HTTPParserError uses HPE_* codes (libhttp-parser convention).
+    if (code && code.startsWith('HPE_')) {
+      return { match: err, kind: 'network' }
+    }
+    if (name === 'HTTPParserError' || name === 'SocketError') {
+      return { match: err, kind: 'network' }
+    }
+  }
+  return null
+}
+
+/**
+ * Inspect a thrown value and, if it looks like a transport-level
+ * failure, return an appropriate typed exception that consumers can
+ * catch via instanceof. Returns null if the error is not transport-level
+ * (programmer errors, server-answered errors with statusCode, etc.) —
+ * callers should rethrow the original error in that case.
+ *
+ * The original error is preserved as `originalError` and `cause` on
+ * any returned wrapper, so consumers walking err.cause keep working.
+ */
+export function classifyTransportError(e: unknown): NetworkError | AbortedError | null {
+  const found = findTransportError(e)
+  if (!found) {
+    return null
+  }
+  const original = e instanceof Error ? e : new Error(String(e))
+  const code: string | undefined = typeof found.match?.code === 'string' ? found.match.code : undefined
+  const detail = found.match?.message ?? original.message ?? 'transport error'
+
+  switch (found.kind) {
+    case 'timeout':
+      return new TimeoutError(detail, original, code)
+    case 'network':
+      return new NetworkError(detail, original, code)
+    case 'aborted':
+      return new AbortedError(detail, original, code)
+  }
+}


### PR DESCRIPTION
## :recycle: Current situation

When a fetch call fails, undici 7+ wraps the underlying error in a
generic `TypeError("fetch failed")` and stashes the real cause one
level deeper at `err.cause`. Consumers wanting to react to specific
transport conditions (timeout, socket reset, intentional abort, etc.)
have to walk that cause chain and reverse-engineer undici's internal
24-class taxonomy themselves.

Concrete production failure: in homebridge-august's connectivity-recovery
state machine, the classifier inspected only level 0 of the error chain
(checking `err.code`, `err.name`, `err.message` against expected
patterns). With undici's wrapping, none of those signals match — the
top-level `TypeError` has no `code`, `name === 'TypeError'`, and
`message === 'fetch failed'`. The error fell through to "transient",
the connectivity state machine never engaged, and the plugin logged
`Polling tick failed: fetch failed` every 30 seconds for hours after a
router blip without ever recovering.

The 24 undici error classes also don't all want the same response.
ConnectTimeoutError, SocketError, HeadersTimeoutError = retry. But
ClientDestroyedError = the consumer asked us to tear down (e.g.
during their own connection-rebuild logic), retrying would be wrong.
InvalidArgumentError = bug in caller's code, retrying would loop
forever. RequestContentLengthMismatchError = caller bug. Lumping them
all together as "network failure" produces incorrect behavior.

## :bulb: Proposed solution

Move the classification into `august-yale` itself. The `fetch()` call
in `src/index.ts` now catches transport failures, walks the cause
chain (depth-capped, cycle-safe), and rethrows as one of three typed
exception classes:

- **`NetworkError`** — transport-level failure. Connect/headers/body
  timeouts, socket reset, malformed response, TLS proxy failure,
  DNS lookup failure, etc. Recoverable by waiting and retrying.

- **`TimeoutError`** — subclass of `NetworkError` for the timeout-specific
  cases. Existing `instanceof TimeoutError` catches keep working;
  callers using the broader `instanceof NetworkError` also see them.

- **`AbortedError`** — in-flight request raced with intentional
  teardown (`UND_ERR_DESTROYED`, `UND_ERR_CLOSED`, `UND_ERR_ABORTED`).
  Distinct from `NetworkError` so consumers retrying on transport
  failure don't also retry on their own intentional aborts.

Programmer errors (`UND_ERR_INVALID_ARG`, `NotSupportedError`,
`RequestContentLengthMismatchError`) and server-answered errors with
`statusCode` are NOT wrapped — they bubble up unchanged so bugs and
HTTP-layer responses remain visible.

Wrapping is fully additive. The original error is preserved on both
`.originalError` and `.cause`, so any existing code walking the cause
chain continues to work. `instanceof TimeoutError` catches still
match (`TimeoutError` keeps its identity). `instanceof YaleApiError`
catches still match (the existing base class is the parent of all
new types).

Classification logic lives in a new `src/util/classify-error.ts`,
exported as `classifyTransportError(e)` for direct use; the wrapping
is applied automatically inside `August.fetch()`.

## :gear: Release Notes

New public exception types: `NetworkError`, `AbortedError`. New
re-exports from the package root.

`TimeoutError` now extends `NetworkError` (was `YaleApiError`
directly). Existing `instanceof TimeoutError` catches and
`instanceof YaleApiError` catches continue to work — this is a
type-hierarchy expansion, not a replacement.

Transport-level failures from the underlying `undici.fetch` call are
now consistently surfaced as one of the typed exceptions. Original
errors are preserved on `.originalError` and `.cause`.

Suggest a minor version bump (1.2.0) since this adds public API.

## :heavy_plus_sign: Additional Information

The 24-class undici taxonomy was enumerated by reading
`node_modules/undici/lib/core/errors.js` directly. Categorization:

| Category | Count | Wrapped as |
|---|---|---|
| Timeout family (UND_ERR_CONNECT_TIMEOUT etc.) | 3 | TimeoutError |
| Generic transport (UND_ERR_SOCKET, UND_ERR_HEADERS_OVERFLOW etc.) | 6 | NetworkError |
| Lifecycle / abort (UND_ERR_DESTROYED, UND_ERR_CLOSED, UND_ERR_ABORTED) | 4 | AbortedError |
| Programmer errors (UND_ERR_INVALID_ARG etc.) | 5 | not wrapped |
| Server-answered (UND_ERR_RESPONSE, UND_ERR_REQ_RETRY) | 2 | not wrapped |
| Other / WebSocket-only | 4 | not wrapped |

POSIX socket codes (`ECONNRESET`, `ETIMEDOUT`, `ENOTFOUND`, etc.) and
`HPE_*` parser codes are also recognized; these can appear on
`err.cause` when undici wraps lower-level Node errors.

### Testing

27 new specs across two files, all passing locally. Suite goes from
~111 to 138.


### Reviewer Nudging
