### PR TITLE
feat: add August.resetTransport() for connectivity recovery

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -169,4 +169,55 @@ describe('august', () => {
     expect(callArgs.dispatcher).toBeDefined()
     expect(callArgs.dispatcher).not.toBe(undefined)
   })
+
+  describe('resetTransport', () => {
+    it('replaces the dispatcher with a fresh one', async () => {
+      const august = new August(mockConfig)
+      // mockImplementation rather than mockResolvedValue so each call
+      // gets a fresh Response — the same instance can only be read once.
+      mockFetch.mockImplementation(async () => new Response('{}', { status: 200 }))
+
+      await august.fetch({ method: 'get', url: '/locks' })
+      const dispatcherBefore = mockFetch.mock.calls[0][1].dispatcher
+
+      august.resetTransport()
+
+      await august.fetch({ method: 'get', url: '/locks' })
+      const dispatcherAfter = mockFetch.mock.calls[1][1].dispatcher
+      expect(dispatcherAfter).not.toBe(dispatcherBefore)
+    })
+
+    it('preserves auth state (token is not cleared)', () => {
+      const august = new August(mockConfig)
+      // Set a token directly to simulate an authenticated state.
+      august.token = 'cached-session-token'
+
+      august.resetTransport()
+
+      // Critical: distinct from destroy(), which clears the token.
+      // The whole point of resetTransport is "shed transport state
+      // without re-authenticating."
+      expect(august.token).toBe('cached-session-token')
+    })
+
+    it('is safe to call multiple times', () => {
+      const august = new August(mockConfig)
+      expect(() => {
+        august.resetTransport()
+        august.resetTransport()
+        august.resetTransport()
+      }).not.toThrow()
+    })
+
+    it('does not throw if the old dispatcher is already broken', async () => {
+      // If the underlying Agent is in a bad state (the case
+      // resetTransport exists to handle), destroy() can reject. The
+      // method must swallow that error so callers can rely on it.
+      const august = new August(mockConfig)
+      const oldDispatcher: any = (august as any).dispatcher
+      oldDispatcher.destroy = () => Promise.reject(new Error('already broken'))
+
+      expect(() => august.resetTransport()).not.toThrow()
+    })
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,11 +56,49 @@ class August {
     this.config = setup(config)
     // Each August instance owns its own connection pool.
     // This prevents a corrupted global pool from permanently breaking
-    // all requests — if this instance's connections go bad, destroy()
-    // + new August() gives a completely fresh pool.
-    this.dispatcher = new Agent({
+    // all requests — if this instance's connections go bad,
+    // resetTransport() (or destroy() + new August()) gives a completely
+    // fresh pool.
+    this.dispatcher = new Agent(August.dispatcherOptions())
+  }
+
+  /**
+   * Default options for the per-instance undici Agent. Extracted as a
+   * static method so resetTransport() can rebuild the dispatcher with
+   * exactly the same configuration the constructor used.
+   */
+  private static dispatcherOptions() {
+    return {
       keepAliveTimeout: 30_000,
       keepAliveMaxTimeout: 60_000,
+    }
+  }
+
+  /**
+   * Throw away the current dispatcher and create a fresh one.
+   *
+   * Use case: connectivity recovery in long-lived consumers (e.g.
+   * homebridge plugins). After a network outage, the existing Agent
+   * may be holding stale half-open sockets that will fail-and-retry
+   * forever even after the network recovers. Calling resetTransport()
+   * gives the next request a clean connection pool without losing
+   * auth state, session token, or configuration — distinct from
+   * destroy() + new August() which discards everything.
+   *
+   * Idempotent. Safe to call from any state. Does not affect PubNub
+   * subscriptions (those use their own August instances created via
+   * August.subscribe()).
+   */
+  resetTransport(): void {
+    const old = this.dispatcher
+    this.dispatcher = new Agent(August.dispatcherOptions())
+    // Destroy the old dispatcher AFTER swapping the reference so any
+    // in-flight request that gets dispatched between these two lines
+    // lands on the new dispatcher rather than the about-to-be-destroyed
+    // old one.
+    old.destroy().catch(() => {
+      // Best effort; an error during destroy of an already-broken
+      // dispatcher is not actionable.
     })
   }
 


### PR DESCRIPTION
## :recycle: Current situation

Long-lived consumers of august-yale that need to recover from a
transport-layer issue (e.g. a homebridge plugin recovering from a
router restart) currently have two options for refreshing the
underlying undici Agent and its connection pool:

1. **Keep the same August instance.** The pool's stale half-open
   sockets from before the outage stay reusable. Connection retries
   land on dead sockets, fail-and-retry forever, system never
   recovers.

2. **`destroy()` + `new August(...)`.** Forces re-authentication on
   the next call (POST /session round-trip). On a still-flaky
   network the auth call itself can fail, leaving the consumer in a
   worse state. Also discards configuration and any other instance
   state, which is more than the consumer wanted.

What's actually missing is a middle option: throw away the
dispatcher (and its socket pool) without losing auth state.

This came up concretely in homebridge-plugins/homebridge-august's
connectivity-recovery state machine. The current workaround there
is to construct a fresh August per probe attempt — the
dispatcher-shedding effect is correct but it pays the auth round-
trip on every probe, and on a flaky network the auth can fail and
worsen recovery.

## :bulb: Proposed solution

A new method on the August class:

```ts
resetTransport(): void
```

Throws away the current dispatcher and creates a fresh one. Auth
state, session token, and configuration are preserved.

Implementation:

- Agent options factored into a private static method
  (`August.dispatcherOptions()`) so the constructor and
  `resetTransport()` build dispatchers identically.
- The new dispatcher is assigned **before** the old one is
  destroyed, so any in-flight request that gets dispatched in the
  small window between those operations lands on the new
  dispatcher rather than the about-to-be-destroyed old one.
- `destroy()`'s rejection is swallowed — the dispatcher is
  presumed to be in a bad state (that's the whole reason callers
  use this method), so an error during destroy is not actionable.

## :gear: Release Notes

New public method `August.resetTransport()`. Throws away the
dispatcher and creates a fresh one without re-authenticating.

No breaking changes. Existing consumers unaffected.

Suggest a minor version bump (1.3.0) since this adds public API.

## :heavy_plus_sign: Additional Information

This unblocks a cleaner connectivity-recovery design in
homebridge-august (PR coming separately). The current PR there
constructs a fresh August per probe attempt to shed stale sockets,
which works but pays the auth round-trip every time. With
`resetTransport()`, probes can reuse the existing client and just
recycle its transport.

### Testing

4 new specs in `src/index.test.ts`

### Reviewer Nudging
