### PR TITLE
fix(session): rejected sessions no longer poison future calls

### DIFF
--- a/src/util/session.test.ts
+++ b/src/util/session.test.ts
@@ -1,9 +1,179 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import * as Session from './session'
+import session from './session'
+
+/**
+ * Build a fake August instance compatible with the `this:` parameter
+ * of session(). Each call to fakeAugust() returns a fresh instance.
+ */
+function fakeAugust(opts: { token?: string | null, fetch: (args: any) => Promise<any> }) {
+  return {
+    token: opts.token ?? null,
+    config: {
+      apiKey: 'k',
+      installId: 'i',
+      password: 'p',
+      idType: 'email',
+      augustId: 'a@b.c',
+    },
+    fetch: opts.fetch,
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 describe('session util', () => {
-  it('should export expected members', () => {
-    expect(Session).toBeDefined()
+  describe('happy paths', () => {
+    it('returns headers with cached token if already authenticated', async () => {
+      const a = fakeAugust({ token: 'cached', fetch: vi.fn() })
+      const headers = await session.call(a) as any
+      expect(headers['x-august-access-token']).toBe('cached')
+      // No fetch should happen when a token is already present.
+      expect(a.fetch).not.toHaveBeenCalled()
+    })
+
+    it('fetches a session and caches the resulting token on the instance', async () => {
+      const fetchFn = vi.fn().mockResolvedValue({
+        headers: { 'x-august-access-token': 'NEW_TOKEN' },
+      })
+      const a = fakeAugust({ token: null, fetch: fetchFn })
+      const headers = await session.call(a) as any
+      expect(fetchFn).toHaveBeenCalledOnce()
+      expect(a.token).toBe('NEW_TOKEN')
+      expect(headers['x-august-access-token']).toBe('NEW_TOKEN')
+    })
+
+    it('coalesces concurrent calls within a single instance', async () => {
+      // Two parallel calls on the SAME instance should share one fetch.
+      let resolveFetch: (v: any) => void = () => {}
+      const fetchFn = vi.fn().mockImplementation(() => new Promise((r) => {
+        resolveFetch = r
+      }))
+      const a = fakeAugust({ token: null, fetch: fetchFn })
+
+      const p1 = session.call(a)
+      const p2 = session.call(a)
+
+      expect(fetchFn).toHaveBeenCalledOnce()
+      resolveFetch({ headers: { 'x-august-access-token': 'TOK' } })
+      await Promise.all([p1, p2])
+      expect(fetchFn).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('cross-instance isolation (architecture)', () => {
+    it('does NOT coalesce calls across distinct August instances', async () => {
+      // Two unrelated August instances each fetching their own session
+      // should make two independent calls. Coalescing across instances
+      // was the previous design and it cross-contaminated rejections.
+      const fetch1 = vi.fn().mockResolvedValue({
+        headers: { 'x-august-access-token': 'TOK1' },
+      })
+      const fetch2 = vi.fn().mockResolvedValue({
+        headers: { 'x-august-access-token': 'TOK2' },
+      })
+      const a = fakeAugust({ token: null, fetch: fetch1 })
+      const b = fakeAugust({ token: null, fetch: fetch2 })
+
+      await Promise.all([session.call(a), session.call(b)])
+      expect(fetch1).toHaveBeenCalledOnce()
+      expect(fetch2).toHaveBeenCalledOnce()
+      expect(a.token).toBe('TOK1')
+      expect(b.token).toBe('TOK2')
+    })
+  })
+
+  describe('regression: rejected session must not poison future calls', () => {
+    // This is the bug this commit fixes. The previous module-level
+    // `request` variable was set to the in-flight promise BEFORE the
+    // await, then cleared to null AFTER the await — but only on the
+    // success path. If the fetch rejected, the rejected promise stayed
+    // cached in the module variable forever, and every subsequent call
+    // from any August instance would re-await it and re-throw the
+    // cached error. Recovery required a process restart.
+
+    it('a rejected session does not poison the next call on the same instance', async () => {
+      const error = new Error('connect timeout')
+      const fetchFn = vi.fn()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValueOnce({
+          headers: { 'x-august-access-token': 'RECOVERY_TOKEN' },
+        })
+
+      const a = fakeAugust({ token: null, fetch: fetchFn })
+
+      // First call fails as expected.
+      await expect(session.call(a)).rejects.toBe(error)
+      // Token must still be unset since the fetch failed.
+      expect(a.token).toBeNull()
+
+      // Second call must trigger a NEW fetch, not re-await the cached
+      // rejected promise. This is the regression assertion.
+      const headers2 = await session.call(a) as any
+      expect(fetchFn).toHaveBeenCalledTimes(2)
+      expect(a.token).toBe('RECOVERY_TOKEN')
+      expect(headers2['x-august-access-token']).toBe('RECOVERY_TOKEN')
+    })
+
+    it('a rejected session on instance A does not poison instance B', async () => {
+      // Even more important: a network blip during one instance's
+      // session fetch must not break a different instance's ability to
+      // authenticate. The previous module-level coalescer shared the
+      // rejected promise across all instances in the process.
+      const errorA = new Error('network down')
+      const fetchA = vi.fn().mockRejectedValueOnce(errorA)
+      const fetchB = vi.fn().mockResolvedValue({
+        headers: { 'x-august-access-token': 'B_TOKEN' },
+      })
+      const a = fakeAugust({ token: null, fetch: fetchA })
+      const b = fakeAugust({ token: null, fetch: fetchB })
+
+      await expect(session.call(a)).rejects.toBe(errorA)
+
+      // Instance B's session must succeed normally — the failure on A
+      // must not be observable here.
+      const headers = await session.call(b) as any
+      expect(b.token).toBe('B_TOKEN')
+      expect(headers['x-august-access-token']).toBe('B_TOKEN')
+      // B made its own fetch call, completely independent of A.
+      expect(fetchB).toHaveBeenCalledOnce()
+    })
+
+    it('repeated rejections retry each time, not just once', async () => {
+      // Each call should attempt a new fetch. If the network stays
+      // down for N retries, we want N fetch attempts, not 1 followed
+      // by N replays of the cached rejection.
+      const fetchFn = vi.fn().mockRejectedValue(new Error('still down'))
+      const a = fakeAugust({ token: null, fetch: fetchFn })
+
+      for (let i = 0; i < 4; i++) {
+        await expect(session.call(a)).rejects.toThrow('still down')
+      }
+      expect(fetchFn).toHaveBeenCalledTimes(4)
+    })
+
+    it('after rejection followed by recovery, the recovered token is saved', async () => {
+      // The full happy-path recovery scenario: bad network, fail,
+      // network comes back, succeed, token is now usable.
+      const fetchFn = vi.fn()
+        .mockRejectedValueOnce(new Error('blip 1'))
+        .mockRejectedValueOnce(new Error('blip 2'))
+        .mockResolvedValueOnce({
+          headers: { 'x-august-access-token': 'RECOVERED' },
+        })
+      const a = fakeAugust({ token: null, fetch: fetchFn })
+
+      await expect(session.call(a)).rejects.toThrow('blip 1')
+      await expect(session.call(a)).rejects.toThrow('blip 2')
+      const headers = await session.call(a) as any
+      expect(a.token).toBe('RECOVERED')
+      expect(headers['x-august-access-token']).toBe('RECOVERED')
+      // Subsequent calls reuse the cached token; no further fetches.
+      const headers2 = await session.call(a) as any
+      expect(fetchFn).toHaveBeenCalledTimes(3)
+      expect(headers2['x-august-access-token']).toBe('RECOVERED')
+    })
   })
 })

--- a/src/util/session.ts
+++ b/src/util/session.ts
@@ -1,4 +1,7 @@
-let request: Promise<any> | null = null
+/**
+ * In-flight session requests, keyed on the August instance.
+ */
+const inflightSessionRequests = new WeakMap<object, Promise<any>>()
 
 /**
  * Start or continue a session
@@ -15,19 +18,32 @@ export default async function session(this: any): Promise<object> {
     'x-kease-api-key': apiKey,
     'Content-Type': 'application/json',
     'Accept-Version': '0.0.1',
-    'x-august-access-token': this.token || '', // Add this line
+    'x-august-access-token': this.token || '',
   }
 
   if (!this.token) {
     const identifier = `${idType}:${augustId}`
-
     const data = { installId, identifier, password }
 
-    if (request === null) {
-      request = this.fetch({ method: 'post', url: 'session', headers, data })
+    let inflight = inflightSessionRequests.get(this)
+    if (!inflight) {
+      inflight = this.fetch({ method: 'post', url: 'session', headers, data })
+      inflightSessionRequests.set(this, inflight!)
     }
-    const response = await request
-    request = null
+
+    let response: any
+    try {
+      response = await inflight
+    } finally {
+      // Clear the inflight entry whether the fetch resolved or rejected.
+      // A rejected promise must NOT stay cached — that was the bug being
+      // fixed here. Clearing in finally also handles cancellation, etc.
+      // Guard against the case where a parallel caller has already
+      // replaced the inflight entry: only delete if it's still ours.
+      if (inflightSessionRequests.get(this) === inflight) {
+        inflightSessionRequests.delete(this)
+      }
+    }
 
     this.token = response.headers['x-august-access-token']
     headers['x-august-access-token'] = this.token


### PR DESCRIPTION
## :recycle: Current situation

Long-running consumers (homebridge plugins in particular) can end up
in a state where every subsequent `session()` call re-throws a stale
`ConnectTimeoutError` indefinitely after a single transient network
failure. Recovery requires a full process restart.

This was diagnosed via instrumented logs from a homebridge-august Pi
running normally for ~24 hours then losing connectivity to August's
API after a router restart. After the network came back:

- `dns.resolve4()` and `dns.lookup()` from the Pi: succeed in <100ms
- `curl https://api-production.august.com`: succeeds with TLS in <300ms
- A fresh `node -e` process using the same undici copy from the
  plugin's `node_modules`: succeeds in <400ms
- The plugin's actual `session()` call: fails with the *exact same*
  `ConnectTimeoutError (attempted addresses: 104.18.43.6:443)` on every
  attempt, including the same address even when DNS returns a different
  set of IPs each query

The address never changing across attempts is the smoking gun. Every
"new" attempt is replaying the *same* error from the original failed
fetch — there's no actual new request happening.

### Root cause

`src/util/session.ts` used a module-level variable to coalesce
concurrent session fetches:

```ts
let request: Promise<any> | null = null

if (request === null) {
  request = this.fetch({ ... })
}
const response = await request
request = null   // <-- only on success path

this.token = response.headers['x-august-access-token']
```

If the fetch rejects, control flow exits via the re-thrown error
*before* `request = null` runs. The rejected promise stays cached in
the module variable forever. Every subsequent call from any August
instance hits `if (request === null)` (false — it's a rejected
promise, not null), skips the fetch, and re-awaits the same rejected
promise, re-throwing the cached error.

Two design issues compound:

1. **Module-level state.** Every August instance in the process
   shares one coalescing slot. A failed session on one instance
   (e.g. a per-lock instance for PubNub) propagates to unrelated
   instances (e.g. a platform's HTTP-polling instance). Each instance
   has its own credentials and its own `this.token`, so coalescing
   across instances was never the right behavior.

2. **Cleanup on success only.** `request = null` should have been in
   a `finally` block from the start.

## :bulb: Proposed solution

Per-instance coalescing via a WeakMap keyed on the August instance,
with `try/finally` cleanup:

```ts
const inflightSessionRequests = new WeakMap<object, Promise<any>>()

let inflight = inflightSessionRequests.get(this)
if (!inflight) {
  inflight = this.fetch({ ... })
  inflightSessionRequests.set(this, inflight)
}
try {
  response = await inflight
} finally {
  if (inflightSessionRequests.get(this) === inflight) {
    inflightSessionRequests.delete(this)
  }
}
```

Three correctness wins over the previous design:

- **Rejected promises no longer poison anything.** The `finally` clears
  the entry whether the fetch resolved or rejected.
- **Cross-instance contamination is gone.** Each August coalesces only
  its own concurrent calls. Two unrelated instances' session fetches
  are independent.
- **WeakMap keys** allow August instances to be garbage-collected
  normally — no manual cleanup needed when the consumer drops a
  reference. (A small architectural win over storing on a regular
  property.)

The within-instance coalescing semantic is preserved: two parallel
`session()` calls on the same August instance still share a single
fetch.

The guard `if (inflightSessionRequests.get(this) === inflight)` covers
the corner case where a different coalesced call has already raced
ahead and started a new entry; we only delete our own.

## :gear: Release Notes

Fix: a transient network failure during a session fetch no longer
poisons all future session calls in the same process. Long-running
consumers (homebridge plugins) recover automatically once the network
comes back, instead of requiring a process restart.

Two changes in observable behavior:

1. After a failed `session()` call, the next call retries the fetch
   (previously it re-threw the cached error).
2. Concurrent `session()` calls are coalesced *per-instance*; calls
   on distinct August instances no longer share a fetch.

No public API changes.

## :heavy_plus_sign: Additional Information

Bug found in production via homebridge-august's connectivity-recovery
state machine looping indefinitely on the same `ConnectTimeoutError`
even after the network had recovered. The state machine could call
`August.resetTransport()` to swap the undici Agent, could even
`destroy()` and rebuild the August instance — and it still made no
difference, because the bad state lived in a module-level variable
below all of that.

### Testing

Replaced the placeholder `src/util/session.test.ts` (1 trivial smoke
test) with 8 specs.

### Reviewer Nudging